### PR TITLE
Fix type of default exported action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-flatpickr-plus",
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"description": "Flatpickr is a lightweight and powerful datetime picker. Svelte Flatpickr Plus is a wrapper for Flatpickr with some extra features.",
 	"homepage": "https://github.com/kodaicoder/svelte-flatpickr-plus",
 	"bugs": {

--- a/src/lib/actions.svelte.js
+++ b/src/lib/actions.svelte.js
@@ -289,7 +289,7 @@ function attachFlatpickr(node, opts, plugins = opts.noCalendar ? [] : [yearDropd
     return fp;
 }
 
-/** @type {import('svelte/action').Action} */
+/** @type {import('./types.js').FlatpickrAction} */
 export default function (node, options = defaultOptions) {
     if (options.isMonthPicker) {
         options = {

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -113,3 +113,8 @@ export default interface FlatpickrOptions {
 	resetMoveDefault?: boolean; // Handling reset and move to calendar to default date.
 	resetToDefault?: boolean; // Handling reset and selected a default date.
 }
+
+export type FlatpickrAction<Node extends HTMLElement> = (
+	node: Node,
+	parameter?: FlatpickrOptions
+) => void | import('svelte/action').ActionReturn<FlatpickrOptions | undefined, any>;


### PR DESCRIPTION
The auto-generated type for the default export of the library is:
```ts
export default function _default<Node extends HTMLElement>(node: Node, parameter?: undefined): void | import("svelte/action").ActionReturn<undefined, any>;
```

The [current documentation](https://svelte.dev/docs/svelte/svelte-action#Action) on `Action`s for Svelte states that "`Action<HTMLDivElement>` and `Action<HTMLDivElement, undefined>` both signal that the action accepts no parameters."

Due to the auto-generated type of the exported action having the parameter be undefined, I got this error:

`Argument of type '{ mode: string; altInput: boolean; altFormat: string; static: boolean; onChange: (v: any) => [any, Date | null]; }' is not assignable to parameter of type 'undefined'.`

![image](https://github.com/user-attachments/assets/51899f91-94ea-464e-b794-a88ae3ba2126)

As best as I can tell, that error is fixed by this PR
